### PR TITLE
could recursively create dir

### DIFF
--- a/src/plugin/savepic/service.js
+++ b/src/plugin/savepic/service.js
@@ -10,7 +10,7 @@ const picDir = () => path.join(config.image.path, moduleName)
 
 function mkdir (dir) {
   if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir)
+    fs.mkdirSync(dir, { recursive: true })
   }
 }
 


### PR DESCRIPTION
允许递归地创建目录
我选择地图片路径为path/to/data
使用savepic时程序会处理成path/to/data/savepic/群号/xxx.jpg
需要创建savepic以及群号两个目录，发生错误
no such file or directory, mkdir 'D:\myfiles\tool\go-cqhttp\data\savepic\552180xxx'